### PR TITLE
Increase client mem from 1 to 2 GB for CoreOS

### DIFF
--- a/client/Vagrantfile
+++ b/client/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
     end
 
     matchbox_client.vm.provider :virtualbox do |vb|
-      vb.memory = '1024'
+      vb.memory = '2048'
       vb.cpus = '1'
       vb.gui = 'true'
 


### PR DESCRIPTION
CoreOS didn't seem to boot before I upgraded the Virtualbox VM memory allocation from 1024 to 2048 MB.