### PR TITLE
Fix network installer and CoreOS internet connectivity

### DIFF
--- a/client/Vagrantfile
+++ b/client/Vagrantfile
@@ -1,11 +1,11 @@
 Vagrant.configure("2") do |config|
   config.vm.define :matchbox_client do |matchbox_client|
 
-    matchbox_client.vm.box = 'debian/jessie64'
+    matchbox_client.vm.box = 'c33s/empty'
 
     matchbox_client.vm.provider :libvirt do |libvirt|
       libvirt.cpu_mode = 'host-passthrough'
-      libvirt.memory = '1024'
+      libvirt.memory = '2024'
       libvirt.cpus = '1'
       libvirt.storage :file, :size => '10G', :type => 'qcow2'
       libvirt.boot 'network'
@@ -24,12 +24,15 @@ Vagrant.configure("2") do |config|
         'modifyvm', :id,
         '--nic1', 'intnet',
         '--intnet1', 'pxe_network',
-        '--boot1', 'net',
-        '--boot2', 'none',
+        '--nic2', 'nat',
+        '--boot1', 'disk',
+        '--boot2', 'net',
         '--boot3', 'none',
         '--boot4', 'none'
       ]
 
+      # Disable question about installation disk on first boot
+      vb.customize [ 'setextradata', :id, 'GUI/FirstRun', 'no' ]
     end
   end
 end

--- a/server/config/setup.sh
+++ b/server/config/setup.sh
@@ -67,11 +67,12 @@ sudo docker run --name matchbox \
   $DATA_MOUNT \
   quay.io/coreos/matchbox:f26224c57dbea02adff0200037b14310ccdd2ebc -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
-sudo docker run -d --rm --cap-add=NET_ADMIN --net=host \
+sudo docker run -d --cap-add=NET_ADMIN --net=host \
   --name=dnsmasq \
   quay.io/coreos/dnsmasq -d -q \
   --dhcp-range=192.168.0.2,192.168.0.253 \
   --enable-tftp --tftp-root=/var/lib/tftpboot \
+  --dhcp-option=3 \
   --dhcp-match=set:bios,option:client-arch,0 \
   --dhcp-boot=tag:bios,undionly.kpxe \
   --dhcp-match=set:efi32,option:client-arch,6 \


### PR DESCRIPTION
Internet connectivity from CoreOS is working with the new NAT interface
Can now pull images from docker hub

- use empty client base image
- add 2nd natted NIC
- disable empty disk prompt
- removed --rm for the matchbox server
- modify gateway ordering /w DHCP option

source: https://github.com/stealthybox/vagrant-matchbox/pull/2#issuecomment-364712737

Thanks to @MPV and @peterrosell for these changes